### PR TITLE
[Feat] #18 - 로그인/회원가입 최종 UI 구현

### DIFF
--- a/fitnow/src/components/KakaoLogin.tsx
+++ b/fitnow/src/components/KakaoLogin.tsx
@@ -3,10 +3,9 @@ import styled from 'styled-components';
 
 const KakaoButton = styled.button`
   width: 100%;
-  height: 36px;
+  height: 40px;
   background-color: #FEE500;
   border: none;
-  border-radius: 0;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/fitnow/src/pages/login/FindIdPage.styled.ts
+++ b/fitnow/src/pages/login/FindIdPage.styled.ts
@@ -1,17 +1,27 @@
 import styled from "styled-components";
 
 export const PageStyled = styled.div`
-  min-height: 100dvh;
+  min-height: calc(100dvh - 200px);
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: ${({ theme }) => theme.spacing.lg} 0;
+  box-sizing: border-box;
 `;
 
 export const CardStyled = styled.div`
   width: 100%;
-  max-width: 500px;
+  max-width: 400px;
   padding: ${({ theme }) => theme.spacing.lg};
   background: ${({ theme }) => theme.colors.surface};
+  margin: 0 auto;
+  flex-shrink: 0;
+  position: relative;
+  transform: translateX(-170px);
+
+  @media (min-width: 640px) {
+    padding: ${({ theme }) => theme.spacing.xl};
+  }
 `;
 
 export const TitleStyled = styled.h2`
@@ -24,12 +34,12 @@ export const TitleStyled = styled.h2`
 
 export const FormStyled = styled.form`
   display: grid;
-  gap: ${({ theme }) => theme.spacing.xs};
+  gap: ${({ theme }) => theme.spacing.lg};
 `;
 
 export const FieldStyled = styled.div`
   display: grid;
-  gap: ${({ theme }) => theme.spacing.xs};
+  gap: ${({ theme }) => theme.spacing.sm};
 `;
 
 export const LabelStyled = styled.label`
@@ -42,23 +52,31 @@ export const PhoneInputContainer = styled.div`
   display: flex;
   gap: ${({ theme }) => theme.spacing.sm};
   align-items: center;
+  justify-content: center;
+  position: relative;
 `;
 
 export const PhoneInput = styled.input`
   flex: 1;
-  padding: ${({ theme }) => theme.spacing.sm} ${({ theme }) => theme.spacing.md};
+  height: 48px;
+  padding: ${({ theme }) => theme.spacing.md} ${({ theme }) => theme.spacing.lg};
   border: 1px solid ${({ theme }) => theme.colors.border};
-  border-radius: 0;
+  border-radius: ${({ theme }) => theme.radii.md};
   font-size: ${({ theme }) => theme.fontSizes.md};
   outline: none;
   transition: box-shadow 0.15s ease, border-color 0.15s ease;
   color: ${({ theme }) => theme.colors.textPrimary};
   background: ${({ theme }) => theme.colors.inputBg};
   text-align: center;
+  box-sizing: border-box;
 
   &:focus {
     border-color: ${({ theme }) => theme.colors.focus};
     box-shadow: 0 0 0 3px ${({ theme }) => theme.focusRing};
+  }
+
+  &:nth-child(2) {
+    position: relative;
   }
 `;
 
@@ -70,14 +88,15 @@ export const VerificationContainer = styled.div`
 
 export const VerificationInput = styled.input`
   flex: 1;
-  padding: ${({ theme }) => theme.spacing.sm} ${({ theme }) => theme.spacing.md};
+  height: 48px;
+  padding: ${({ theme }) => theme.spacing.md} ${({ theme }) => theme.spacing.lg};
   border: 1px solid ${({ theme }) => theme.colors.border};
-  border-radius: 0;
-  font-size: ${({ theme }) => theme.fontSizes.md};
+    font-size: ${({ theme }) => theme.fontSizes.md};
   outline: none;
   transition: box-shadow 0.15s ease, border-color 0.15s ease;
   color: ${({ theme }) => theme.colors.textPrimary};
   background: ${({ theme }) => theme.colors.inputBg};
+  box-sizing: border-box;
 
   &:focus {
     border-color: ${({ theme }) => theme.colors.focus};
@@ -86,14 +105,15 @@ export const VerificationInput = styled.input`
 `;
 
 export const VerifyButton = styled.button`
-  padding: ${({ theme }) => theme.spacing.sm} ${({ theme }) => theme.spacing.md};
+  height: 48px;
+  padding: ${({ theme }) => theme.spacing.md} ${({ theme }) => theme.spacing.lg};
   border: 1px solid ${({ theme }) => theme.colors.border};
-  border-radius: 0;
-  font-size: ${({ theme }) => theme.fontSizes.sm};
+  font-size: ${({ theme }) => theme.fontSizes.md};
   color: ${({ theme }) => theme.colors.textPrimary};
   background: ${({ theme }) => theme.colors.surface};
   cursor: pointer;
   transition: background 0.15s ease;
+  white-space: nowrap;
 
   &:hover {
     background: ${({ theme }) => theme.colors.hover};
@@ -102,17 +122,16 @@ export const VerifyButton = styled.button`
 
 export const ButtonContainer = styled.div`
   display: grid;
-  gap: ${({ theme }) => theme.spacing.sm};
+  gap: ${({ theme }) => theme.spacing.md};
   margin-top: ${({ theme }) => theme.spacing.lg};
 `;
 
 export const SendButton = styled.button`
   width: 100%;
-  height: 36px;
+  height: 40px;
   border: 1px solid ${({ theme }) => theme.colors.border};
-  border-radius: 0;
   font-weight: 500;
-  font-size: ${({ theme }) => theme.fontSizes.sm};
+  font-size: ${({ theme }) => theme.fontSizes.md};
   color: ${({ theme }) => theme.colors.textPrimary};
   background: ${({ theme }) => theme.colors.surface};
   cursor: pointer;
@@ -125,18 +144,13 @@ export const SendButton = styled.button`
 
 export const NextButton = styled.button<{ $disabled?: boolean }>`
   width: 100%;
-  height: 36px;
+  height: 40px;
   border: 0;
-  border-radius: 0;
   font-weight: 500;
-  font-size: ${({ theme }) => theme.fontSizes.sm};
+  font-size: ${({ theme }) => theme.fontSizes.md};
   color: ${({ theme }) => theme.colors.onPrimary};
   background: ${({ $disabled, theme }) => 
     $disabled ? theme.colors.border : theme.colors.primary};
-  border: none;
-  border-radius: 0;
-  font-weight: 500;
-  font-size: ${({ theme }) => theme.fontSizes.sm};
   cursor: ${({ $disabled }) => $disabled ? 'not-allowed' : 'pointer'};
   transition: background 0.15s ease;
 

--- a/fitnow/src/pages/login/FindIdResultPage.styled.ts
+++ b/fitnow/src/pages/login/FindIdResultPage.styled.ts
@@ -1,10 +1,11 @@
 import styled from "styled-components";
 
 export const PageStyled = styled.div`
-  min-height: 100dvh;
+  min-height: calc(100dvh - 200px);
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: ${({ theme }) => theme.spacing.lg} 0;
 `;
 
 export const CardStyled = styled.div`

--- a/fitnow/src/pages/login/LoginPage.styled.ts
+++ b/fitnow/src/pages/login/LoginPage.styled.ts
@@ -1,24 +1,17 @@
-// 1) React / 라이브러리
 import styled from "styled-components";
 
-// 2) 절대경로 import
-
-// 3) 상대경로 import (부모 → 자식)
-
-// 4) styled-components 마지막 (현재 파일 자체)
-
-// 모든 색상/간격/반경은 theme 사용 (하드코딩 금지)
 export const PageStyled = styled.div`
-  min-height: 100dvh;
+  min-height: calc(100dvh - 200px);
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: ${({ theme }) => theme.spacing.lg} 0;
 `;
 
 export const CardStyled = styled.div`
   width: 100%;
-  max-width: 420px;
-  padding: ${({ theme }) => theme.spacing.lg};
+  max-width: 480px;
+  padding: ${({ theme }) => theme.spacing.xl};
   background: ${({ theme }) => theme.colors.surface};
 
   @media (min-width: 640px) {
@@ -29,7 +22,7 @@ export const CardStyled = styled.div`
 export const TitleStyled = styled.h2`
   font-size: ${({ theme }) => theme.fontSizes.xl};
   font-weight: 700;
-  margin: 0 0 ${({ theme }) => theme.spacing.md};
+  margin: 0 0 ${({ theme }) => theme.spacing.lg};
   color: ${({ theme }) => theme.colors.textPrimary};
   text-align: left;
 `;
@@ -44,12 +37,12 @@ export const ErrorTextStyled = styled.p`
 
 export const FormStyled = styled.form`
   display: grid;
-  gap: ${({ theme }) => theme.spacing.md};
+  gap: ${({ theme }) => theme.spacing.lg};
 `;
 
 export const FieldStyled = styled.div`
   display: grid;
-  gap: ${({ theme }) => theme.spacing.xs};
+  gap: ${({ theme }) => theme.spacing.sm};
 `;
 
 export const LabelStyled = styled.label`
@@ -59,8 +52,9 @@ export const LabelStyled = styled.label`
 `;
 
 export const InputStyled = styled.input`
-  width: 92%;
-  padding: ${({ theme }) => theme.spacing.sm} ${({ theme }) => theme.spacing.md};
+  width: 100%;
+  height: 48px;
+  padding: ${({ theme }) => theme.spacing.md} ${({ theme }) => theme.spacing.lg};
   border: 1px solid ${({ theme }) => theme.colors.border};
   border-radius: ${({ theme }) => theme.radii.md};
   font-size: ${({ theme }) => theme.fontSizes.md};
@@ -68,6 +62,7 @@ export const InputStyled = styled.input`
   transition: box-shadow 0.15s ease, border-color 0.15s ease;
   color: ${({ theme }) => theme.colors.textPrimary};
   background: ${({ theme }) => theme.colors.inputBg};
+  box-sizing: border-box;
 
   &:focus {
     border-color: ${({ theme }) => theme.colors.focus};
@@ -121,16 +116,16 @@ export const LinkGroupStyled = styled.div`
 
 export const ActionsStyled = styled.div`
   display: grid;
-  gap: ${({ theme }) => theme.spacing.lg};
+  gap: ${({ theme }) => theme.spacing.md};
   margin-top: ${({ theme }) => theme.spacing.xs};
 `;
 
 export const PrimaryButtonStyled = styled.button<{ $loading?: boolean }>`
   width: 100%;
-  height: 36px;
+  height: 40px;
   border: 0;
-  border-radius: 0;
   font-weight: 700;
+  font-size: ${({ theme }) => theme.fontSizes.md};
   color: ${({ theme }) => theme.colors.onPrimary};
   background: ${({ theme }) => theme.colors.primary};
   cursor: pointer;
@@ -150,12 +145,12 @@ export const PrimaryButtonStyled = styled.button<{ $loading?: boolean }>`
 
 export const OutlineButtonStyled = styled.button`
   width: 100%;
-  height: 36px;
+  height: 40px;
   background: ${({ theme }) => theme.colors.surface};
   color: ${({ theme }) => theme.colors.textPrimary};
   border: 1px solid ${({ theme }) => theme.colors.textPrimary};
-  border-radius: 0;
   font-weight: 700;
+  font-size: ${({ theme }) => theme.fontSizes.md};
   cursor: pointer;
   transition: background 0.15s ease;
 
@@ -165,7 +160,7 @@ export const OutlineButtonStyled = styled.button`
 `;
 
 export const NoticeStyled = styled.p`
-  margin-top: ${({ theme }) => theme.spacing.md};
+  margin-top: ${({ theme }) => theme.spacing.lg};
   text-align: center;
   font-size: ${({ theme }) => theme.fontSizes.sm};
   color: ${({ theme }) => theme.colors.textSecondary};

--- a/fitnow/src/pages/login/ResetPasswordPage.styled.ts
+++ b/fitnow/src/pages/login/ResetPasswordPage.styled.ts
@@ -1,10 +1,11 @@
 import styled from "styled-components";
 
 export const PageStyled = styled.div`
-  min-height: 100dvh;
+  min-height: calc(100dvh - 200px);
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: ${({ theme }) => theme.spacing.lg} 0;
 `;
 
 export const CardStyled = styled.div`

--- a/fitnow/src/pages/login/SignupPage.styled.ts
+++ b/fitnow/src/pages/login/SignupPage.styled.ts
@@ -1,10 +1,11 @@
 import styled from "styled-components";
 
 export const PageStyled = styled.div`
-  min-height: 100dvh;
+  min-height: calc(100dvh - 200px);
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: ${({ theme }) => theme.spacing.lg} 0;
 `;
 
 export const CardStyled = styled.div`
@@ -69,6 +70,33 @@ export const SelectStyled = styled.select`
   &:focus {
     border-color: ${({ theme }) => theme.colors.focus};
     box-shadow: 0 0 0 3px ${({ theme }) => theme.focusRing};
+  }
+`;
+
+export const GenderButtonContainer = styled.div`
+  display: flex;
+  gap: ${({ theme }) => theme.spacing.sm};
+`;
+
+export const GenderButton = styled.button<{ $selected?: boolean }>`
+  flex: 1;
+  height: 36px;
+  border: 1px solid ${({ theme, $selected }) => 
+    $selected ? theme.colors.primary : theme.colors.border};
+  border-radius: ${({ theme }) => theme.radii.md};
+  font-size: ${({ theme }) => theme.fontSizes.md};
+  font-weight: 500;
+  color: ${({ theme, $selected }) => 
+    $selected ? theme.colors.onPrimary : theme.colors.textPrimary};
+  background: ${({ theme, $selected }) => 
+    $selected ? theme.colors.primary : theme.colors.inputBg};
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    border-color: ${({ theme }) => theme.colors.primary};
+    background: ${({ theme, $selected }) => 
+      $selected ? theme.colors.primary : theme.colors.hover};
   }
 `;
 

--- a/fitnow/src/pages/login/SignupPage.tsx
+++ b/fitnow/src/pages/login/SignupPage.tsx
@@ -8,7 +8,8 @@ import {
   FieldStyled,
   LabelStyled,
   InputStyled,
-  SelectStyled,
+  GenderButtonContainer,
+  GenderButton,
   FileUploadContainer,
   FileInput,
   FileLabel,
@@ -36,6 +37,13 @@ const SignupPage: React.FC = () => {
     }));
   };
 
+  const handleGenderChange = (gender: string) => {
+    setFormData(prev => ({
+      ...prev,
+      gender: gender,
+    }));
+  };
+
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file && file.type === "image/jpeg") {
@@ -51,9 +59,9 @@ const SignupPage: React.FC = () => {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     
-    // 필수 필드 검증
-    if (!formData.id || !formData.password || !formData.birthDate || !formData.height || !formData.weight || !formData.userId || !formData.gender || !formData.fullBodyPhoto) {
-      alert("모든 필드를 입력해주세요.");
+    // 필수 필드 검증 (전신사진 제외)
+    if (!formData.id || !formData.password || !formData.birthDate || !formData.height || !formData.weight || !formData.userId || !formData.gender) {
+      alert("필수 필드를 모두 입력해주세요.");
       return;
     }
 
@@ -139,29 +147,35 @@ const SignupPage: React.FC = () => {
 
           <FieldStyled>
             <LabelStyled>성별 *</LabelStyled>
-            <SelectStyled
-              value={formData.gender}
-              onChange={(e) => handleInputChange("gender", e.target.value)}
-              required
-            >
-              <option value="">성별을 선택하세요</option>
-              <option value="male">남성</option>
-              <option value="female">여성</option>
-            </SelectStyled>
+            <GenderButtonContainer>
+              <GenderButton
+                type="button"
+                $selected={formData.gender === "male"}
+                onClick={() => handleGenderChange("male")}
+              >
+                남성
+              </GenderButton>
+              <GenderButton
+                type="button"
+                $selected={formData.gender === "female"}
+                onClick={() => handleGenderChange("female")}
+              >
+                여성
+              </GenderButton>
+            </GenderButtonContainer>
           </FieldStyled>
 
           <FieldStyled>
-            <LabelStyled>전신 사진 *</LabelStyled>
+            <LabelStyled>전신 사진 (선택 사항)</LabelStyled>
             <FileUploadContainer>
               <FileInput
                 type="file"
                 id="fullBodyPhoto"
                 accept=".jpg,.jpeg"
                 onChange={handleFileChange}
-                required
               />
               <FileLabel htmlFor="fullBodyPhoto">
-                {formData.fullBodyPhoto ? formData.fullBodyPhoto.name : "JPG 파일을 선택하세요"}
+                {formData.fullBodyPhoto ? formData.fullBodyPhoto.name : "업로드할 파일을 선택해주세요"}
               </FileLabel>
             </FileUploadContainer>
           </FieldStyled>


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
- 로그인 폼 크기 및 레이아웃 개선
- 아이디 찾기 페이지 중앙 정렬 문제 해결
- 모든 페이지의 Header-Footer 간 여백 최적화
- 회원가입 페이지 UI/UX 개선(기존 드롭다운 방식 -> 버튼 두개(남성/여성)으로 변경)
- 불필요한 코드 정리(린터 오류 해결)


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- close: #18 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->
<img width="1440" height="900" alt="로그인 페이지" src="https://github.com/user-attachments/assets/710607b8-d751-4c6c-8225-9bcdcf9bcfc6" />

<img width="1440" height="900" alt="회원가입 페이지" src="https://github.com/user-attachments/assets/789c9812-14f5-4124-9f80-734d3fbce071" />

<img width="1440" height="900" alt="아이디 찾기 페이지" src="https://github.com/user-attachments/assets/2ff1ab2e-6738-4d89-bf4d-adebd3ede2b8" />

<img width="1440" height="900" alt="비밀번호 찾기 페이지" src="https://github.com/user-attachments/assets/1eb0def4-2807-43a9-bfec-b3168fcf2931" />